### PR TITLE
Remove version from plugin to use latest

### DIFF
--- a/cdk/stacks/grafana/grafana_stack.py
+++ b/cdk/stacks/grafana/grafana_stack.py
@@ -109,7 +109,7 @@ class GrafanaStack(core.Stack):
             image=ecs.ContainerImage.from_registry("grafana/grafana"),
             logging=container_log_driver,
             environment={
-                "GF_INSTALL_PLUGINS": "grafana-timestream-datasource 1.1.0",
+                "GF_INSTALL_PLUGINS": "grafana-timestream-datasource",
                 "GF_AWS_default_REGION": core.Aws.REGION
             },
             secrets={


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

- Remove version from grafana amazon timestream plugin in container environment to use latest version

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
