### PR TITLE
Improved producer: scatter data points and anomalies

### DIFF
--- a/cdk/stacks/grafana/dashboard.json
+++ b/cdk/stacks/grafana/dashboard.json
@@ -329,7 +329,7 @@
             "fill": true,
             "line": true,
             "op": "gt",
-            "value": 290,
+            "value": 400,
             "yaxis": "left"
           },
           {

--- a/cdk/stacks/sample_kinesis_stream_producer/producer_lambda/config.py
+++ b/cdk/stacks/sample_kinesis_stream_producer/producer_lambda/config.py
@@ -63,3 +63,5 @@ measures = [
 ]
 
 iterations = 10
+
+chance_of_anomaly = 0.051


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

* Introduce an anomaly mechanism for a chance to put a data point totally outside of the safe ranges
  * Anomalies are triggered by setting chance_of_anomaly = 0.051 in config.py
  * Setting it to 0 will disable any anomalies
* Introduce the mechanism to scatter data and add a simulation for late arriving data
  * All iteration data points were produced when the producer is invoked
  * Now they are simulated to be spread out by adding a uniform delta based on iteration index

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
